### PR TITLE
TwinPeaks: remove `onSampleRateChange()`

### DIFF
--- a/src/TwinPeaks.cpp
+++ b/src/TwinPeaks.cpp
@@ -73,7 +73,6 @@ struct TwinPeaks : Module {
 
         configOutput(OUT_OUTPUT, "Audio");
         configBypass(IN_INPUT, OUT_OUTPUT);
-        onSampleRateChange();
     }
 
     void onReset() override {


### PR DESCRIPTION
Not needed as Rack always calls `onSampleRateChange` for added modules. See:
https://github.com/VCVRack/Rack/blob/v2/src/engine/Engine.cpp#L745-L749